### PR TITLE
chore: add golangci-lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,10 @@ jobs:
         run: |
           make install-dev-cmds
           make check
+
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           make check
 
   golangci-lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/cmd/jpgo/main.go
+++ b/cmd/jpgo/main.go
@@ -1,18 +1,18 @@
-/*Basic command line interface for debug and testing purposes.
+/*
+Basic command line interface for debug and testing purposes.
 
 Examples:
 
 Only print the AST for the expression:
 
-    jp.go -ast "foo.bar.baz"
+	jp.go -ast "foo.bar.baz"
 
 Evaluate the JMESPath expression against JSON data from a file:
 
-    jp.go -input /tmp/data.json "foo.bar.baz"
+	jp.go -input /tmp/data.json "foo.bar.baz"
 
 This program can also be used as an executable to the jp-compliance
 runner (github.com/jmespath-community/jmespath.test).
-
 */
 package main
 
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/jmespath-community/go-jmespath"
@@ -62,14 +62,14 @@ func run() int {
 
 	var inputData []byte
 	if *inputFile != "" {
-		inputData, err = ioutil.ReadFile(*inputFile)
+		inputData, err = os.ReadFile(*inputFile)
 		if err != nil {
 			return errMsg("Error loading file %s: %s", *inputFile, err)
 		}
 	} else {
 		// If an input data file is not provided then we read the
 		// data from stdin.
-		inputData, err = ioutil.ReadAll(os.Stdin)
+		inputData, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			return errMsg("Error reading from stdin: %s", err)
 		}

--- a/compliance_test.go
+++ b/compliance_test.go
@@ -3,7 +3,6 @@ package jmespath
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,7 +76,7 @@ func TestCompliance(t *testing.T) {
 
 func runComplianceTest(assert *assert.Assertions, filename string) {
 	var testSuites []TestSuite
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if assert.Nil(err) {
 		err := json.Unmarshal(data, &testSuites)
 		if assert.Nil(err) {


### PR DESCRIPTION
This PR adds a `golangci-lint` job.

cc @springcomp looks like gh actions are not running, are they disabled when PRs come from forks ?