### PR TITLE
chore: add go 1.19 and remove below 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,8 @@ jobs:
     strategy:
       matrix:
         go-version:
+          - 1.19
           - 1.18
-          - 1.17
-          - 1.16
-          - 1.15
     steps:
       - uses: actions/checkout@v2
       - name: Set up Go


### PR DESCRIPTION
This PR adds go 1.19 and remove below 1.18.