### PR TITLE
refactor: introduce Scope interface and make scopes immutable

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -58,6 +58,12 @@ func TestSearch(t *testing.T) {
 			expression: "not a valid expression",
 		},
 		wantErr: true,
+	}, {
+		args: args{
+			expression: "let({root: @}, &root).root",
+			data:       map[string]interface{}{},
+		},
+		wantErr: false,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/interpreter/functions.go
+++ b/pkg/interpreter/functions.go
@@ -126,11 +126,10 @@ func (a *byExprFloat) Less(i, j int) bool {
 
 type functionCaller struct {
 	functionTable map[string]functionEntry
-	scopes        *scopes
 }
 
-func newFunctionCaller(scopes *scopes) *functionCaller {
-	caller := &functionCaller{scopes: scopes}
+func newFunctionCaller() *functionCaller {
+	caller := &functionCaller{}
 	caller.functionTable = map[string]functionEntry{
 		"abs": {
 			name: "abs",
@@ -790,8 +789,7 @@ func (fCall *functionCaller) jpfLet(arguments []interface{}) (interface{}, error
 	node := exp.ref
 	context := exp.context
 
-	fCall.scopes.pushScope(scope)
-	result, err := intr.Execute(node, context)
+	result, err := intr.WithScope(scope).Execute(node, context)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/interpreter/functions.go
+++ b/pkg/interpreter/functions.go
@@ -129,12 +129,12 @@ func (a *byExprFloat) Less(i, j int) bool {
 }
 
 type functionCaller struct {
-	functionTable map[string]functionEntry
+	functionTable map[string]FunctionEntry
 }
 
 func newFunctionCaller() *functionCaller {
 	caller := &functionCaller{}
-	caller.functionTable = map[string]functionEntry{
+	caller.functionTable = map[string]FunctionEntry{
 		"abs": {
 			Name: "abs",
 			Arguments: []ArgSpec{

--- a/pkg/interpreter/functions.go
+++ b/pkg/interpreter/functions.go
@@ -797,9 +797,9 @@ func (f *functionCaller) jpfLet(arguments []interface{}) (interface{}, error) {
 	context := exp.context
 
 	result, err := intr.WithScope(scope).Execute(node, context)
+	if err != nil {
 		return nil, err
 	}
-
 	return result, nil
 }
 

--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -18,27 +18,31 @@ This is a tree based interpreter.  It walks the AST and directly
 */
 type Interpreter interface {
 	Execute(parsing.ASTNode, interface{}) (interface{}, error)
+	WithScope(map[string]interface{}) Interpreter
 }
 
 type treeInterpreter struct {
-	fCall  *functionCaller
-	scopes *scopes
+	fCall *functionCaller
+	scope Scope
 }
 
 func NewInterpreter(data interface{}) Interpreter {
-	interpreter := treeInterpreter{
-		scopes: newScopes(),
+	return &treeInterpreter{
+		fCall: newFunctionCaller(),
+		scope: newScope(map[string]interface{}{"$": data}),
 	}
-	interpreter.scopes.pushScope(map[string]interface{}{"$": data})
-
-	interpreter.fCall = newFunctionCaller(interpreter.scopes)
-
-	return &interpreter
 }
 
 type expRef struct {
 	ref     parsing.ASTNode
 	context interface{}
+}
+
+func (intr *treeInterpreter) WithScope(data map[string]interface{}) Interpreter {
+	return &treeInterpreter{
+		fCall: intr.fCall,
+		scope: intr.scope.With(data),
+	}
 }
 
 // Execute takes an ASTNode and input data and interprets the AST directly.
@@ -155,7 +159,7 @@ func (intr *treeInterpreter) Execute(node parsing.ASTNode, value interface{}) (i
 		if result != nil {
 			return result, nil
 		}
-		if result, ok := intr.scopes.getValue(key); ok {
+		if result, ok := intr.scope.GetValue(key); ok {
 			return result, nil
 		}
 		return nil, nil
@@ -223,7 +227,7 @@ func (intr *treeInterpreter) Execute(node parsing.ASTNode, value interface{}) (i
 	case parsing.ASTIdentity, parsing.ASTCurrentNode:
 		return value, nil
 	case parsing.ASTRootNode:
-		if result, ok := intr.scopes.getValue("$"); ok {
+		if result, ok := intr.scope.GetValue("$"); ok {
 			return result, nil
 		}
 		return nil, nil

--- a/pkg/interpreter/scopes.go
+++ b/pkg/interpreter/scopes.go
@@ -1,36 +1,37 @@
 package interpreter
 
-type scopes struct {
-	stack []map[string]interface{} // The stack of scope JSON objects.
+type Scope interface {
+	GetValue(string) (interface{}, bool)
+	With(data map[string]interface{}) Scope
 }
 
-// newScopes creates a new instance of JMESPath scopes.
-func newScopes() *scopes {
-	stack := []map[string]interface{}{}
-	scopes := scopes{stack: stack}
-	return &scopes
+type scope struct {
+	inner Scope
+	data  map[string]interface{}
 }
 
-func (scopes *scopes) pushScope(item map[string]interface{}) {
-	scopes.stack = append(scopes.stack, item)
-}
-
-func (scopes *scopes) popScope() map[string]interface{} {
-	if len(scopes.stack) == 0 {
-		panic("unable to pop empty scopes stack")
+// newScope creates a new instance of JMESPath scope.
+func newScope(data map[string]interface{}) Scope {
+	return scope{
+		data: data,
 	}
-	result := scopes.stack[len(scopes.stack)-1]
-	scopes.stack = scopes.stack[:len(scopes.stack)-1]
-	return result
 }
 
-func (scopes *scopes) getValue(identifier string) (interface{}, bool) {
-	stack := scopes.stack
-	for i := len(stack) - 1; i >= 0; i-- {
-		scope := stack[i]
-		if item, ok := scope[identifier]; ok {
+func (s scope) GetValue(identifier string) (interface{}, bool) {
+	if s.data != nil {
+		if item, ok := s.data[identifier]; ok {
 			return item, true
 		}
 	}
+	if s.inner != nil {
+		return s.inner.GetValue(identifier)
+	}
 	return nil, false
+}
+
+func (s scope) With(data map[string]interface{}) Scope {
+	return scope{
+		data:  data,
+		inner: s,
+	}
 }

--- a/pkg/interpreter/scopes_test.go
+++ b/pkg/interpreter/scopes_test.go
@@ -8,42 +8,45 @@ import (
 
 func TestScopesMissing(t *testing.T) {
 	assert := assert.New(t)
-	scopes := newScopes()
+	scopes := newScope(nil)
 
-	_, found := scopes.getValue("foo")
+	_, found := scopes.GetValue("foo")
 	assert.False(found)
 }
 
 func TestScopesRoot(t *testing.T) {
 	assert := assert.New(t)
-	scopes := newScopes()
-	scopes.pushScope(map[string]interface{}{"foo": "bar"})
+	scopes := newScope(map[string]interface{}{"foo": "bar"})
 
-	value, found := scopes.getValue("foo")
+	value, found := scopes.GetValue("foo")
 	assert.True(found)
 	assert.Equal("bar", value.(string))
 }
 
 func TestScopesNested(t *testing.T) {
 	assert := assert.New(t)
-	scopes := newScopes()
-	scopes.pushScope(map[string]interface{}{"foo": "bar", "qux": "quux"})
-	scopes.pushScope(map[string]interface{}{"foo": "baz"})
+	scopes := newScope(nil)
 
-	value, found := scopes.getValue("foo")
-	assert.True(found)
-	assert.Equal("baz", value.(string))
+	{
+		scopes := scopes.With(map[string]interface{}{"foo": "bar", "qux": "quux"})
 
-	value, found = scopes.getValue("qux")
-	assert.True(found)
-	assert.Equal("quux", value.(string))
+		{
+			scopes := scopes.With(map[string]interface{}{"foo": "baz"})
 
-	scopes.popScope()
-	value, found = scopes.getValue("foo")
-	assert.True(found)
-	assert.Equal("bar", value.(string))
+			value, found := scopes.GetValue("foo")
+			assert.True(found)
+			assert.Equal("baz", value.(string))
 
-	scopes.popScope()
-	_, found = scopes.getValue("foo")
+			value, found = scopes.GetValue("qux")
+			assert.True(found)
+			assert.Equal("quux", value.(string))
+		}
+
+		value, found := scopes.GetValue("foo")
+		assert.True(found)
+		assert.Equal("bar", value.(string))
+	}
+
+	_, found := scopes.GetValue("foo")
 	assert.False(found)
 }


### PR DESCRIPTION
This PR introduces a `Scope` interface and makes scopes immutable.

With this PR scopes are chained together creating a new scope every time we add an element in the chain, this way we don't need to push/pop elements.