### PR TITLE
refactor: use type alias for jp function

### DIFF
--- a/pkg/interpreter/functions.go
+++ b/pkg/interpreter/functions.go
@@ -17,7 +17,7 @@ import (
 	"github.com/jmespath-community/go-jmespath/pkg/util"
 )
 
-type JpFunction func(arguments []interface{}) (interface{}, error)
+type JpFunction = func(arguments []interface{}) (interface{}, error)
 
 type JpType string
 


### PR DESCRIPTION
This PR uses a type alias for `JpFunction`.