### PR TITLE
fix: incorrect access to root node

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -120,6 +120,14 @@ func TestSearch(t *testing.T) {
 			data:       42.0,
 		},
 		wantErr: true,
+	}, {
+		args: args{
+			expression: `@."$".a`,
+			data: map[string]interface{}{
+				"a": 42.0,
+			},
+		},
+		want: nil,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR fixes an incorrect access to root node when using an inexistent `$` field.

Fixes #44 

@springcomp I need your opinion on this, it looks like a bug to me. WDYT ?