### PR TITLE
refactor: don't rebuild function caller every time

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -15,14 +15,14 @@ type JMESPath interface {
 }
 
 type jmesPath struct {
-	node  parsing.ASTNode
-	funcs []functions.FunctionEntry
+	node   parsing.ASTNode
+	caller interpreter.FunctionCaller
 }
 
 func newJMESPath(node parsing.ASTNode, funcs ...functions.FunctionEntry) JMESPath {
 	return jmesPath{
-		node:  node,
-		funcs: funcs,
+		node:   node,
+		caller: interpreter.NewFunctionCaller(funcs...),
 	}
 }
 
@@ -53,7 +53,7 @@ func MustCompile(expression string, funcs ...functions.FunctionEntry) JMESPath {
 
 // Search evaluates a JMESPath expression against input data and returns the result.
 func (jp jmesPath) Search(data interface{}) (interface{}, error) {
-	intr := interpreter.NewInterpreter(data, jp.funcs...)
+	intr := interpreter.NewInterpreter(data, jp.caller)
 	return intr.Execute(jp.node, data)
 }
 

--- a/pkg/interpreter/functions.go
+++ b/pkg/interpreter/functions.go
@@ -10,6 +10,10 @@ import (
 	"github.com/jmespath-community/go-jmespath/pkg/util"
 )
 
+type FunctionCaller interface {
+	CallFunction(string, []interface{}, Interpreter) (interface{}, error)
+}
+
 type functionEntry struct {
 	arguments []functions.ArgSpec
 	handler   functions.JpFunction
@@ -19,7 +23,7 @@ type functionCaller struct {
 	functionTable map[string]functionEntry
 }
 
-func newFunctionCaller(funcs ...functions.FunctionEntry) *functionCaller {
+func NewFunctionCaller(funcs ...functions.FunctionEntry) *functionCaller {
 	fTable := map[string]functionEntry{}
 	for _, f := range funcs {
 		fTable[f.Name] = functionEntry{
@@ -143,7 +147,7 @@ func typeCheck(a functions.ArgSpec, arg interface{}) error {
 	return fmt.Errorf("invalid type for: %v, expected: %#v", arg, a.Types)
 }
 
-func (f *functionCaller) callFunction(name string, arguments []interface{}, intr Interpreter) (interface{}, error) {
+func (f *functionCaller) CallFunction(name string, arguments []interface{}, intr Interpreter) (interface{}, error) {
 	entry, ok := f.functionTable[name]
 	if !ok {
 		return nil, errors.New("unknown function: " + name)

--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -23,24 +23,24 @@ type Interpreter interface {
 }
 
 type treeInterpreter struct {
-	fCall *functionCaller
-	scope Scope
-	root  interface{}
+	caller FunctionCaller
+	scope  Scope
+	root   interface{}
 }
 
-func NewInterpreter(data interface{}, funcs ...functions.FunctionEntry) Interpreter {
+func NewInterpreter(data interface{}, caller FunctionCaller) Interpreter {
 	return &treeInterpreter{
-		fCall: newFunctionCaller(funcs...),
-		scope: newScope(nil),
-		root:  data,
+		caller: caller,
+		scope:  newScope(nil),
+		root:   data,
 	}
 }
 
 func (intr *treeInterpreter) WithScope(data map[string]interface{}) Interpreter {
 	return &treeInterpreter{
-		fCall: intr.fCall,
-		scope: intr.scope.With(data),
-		root:  intr.root,
+		caller: intr.caller,
+		scope:  intr.scope.With(data),
+		root:   intr.root,
 	}
 }
 
@@ -144,7 +144,7 @@ func (intr *treeInterpreter) Execute(node parsing.ASTNode, value interface{}) (i
 			}
 			resolvedArgs = append(resolvedArgs, current)
 		}
-		return intr.fCall.callFunction(node.Value.(string), resolvedArgs, intr)
+		return intr.caller.CallFunction(node.Value.(string), resolvedArgs, intr)
 	case parsing.ASTField:
 		key := node.Value.(string)
 		var result interface{}

--- a/pkg/interpreter/interpreter_test.go
+++ b/pkg/interpreter/interpreter_test.go
@@ -51,7 +51,8 @@ func search(t *testing.T, expression string, data interface{}) (interface{}, err
 	if err != nil {
 		return nil, err
 	}
-	intr := NewInterpreter(nil, functions.GetDefaultFunctions()...)
+	caller := NewFunctionCaller(functions.GetDefaultFunctions()...)
+	intr := NewInterpreter(nil, caller)
 	return intr.Execute(ast, data)
 }
 
@@ -196,7 +197,8 @@ func TestCanSupportSliceOfStructsWithFunctions(t *testing.T) {
 
 func BenchmarkInterpretSingleFieldStruct(b *testing.B) {
 	assert := assert.New(b)
-	intr := NewInterpreter(nil, functions.GetDefaultFunctions()...)
+	caller := NewFunctionCaller(functions.GetDefaultFunctions()...)
+	intr := NewInterpreter(nil, caller)
 	parser := parsing.NewParser()
 	ast, _ := parser.Parse("fooasdfasdfasdfasdf")
 	data := benchmarkStruct{"foobarbazqux"}
@@ -210,7 +212,8 @@ func BenchmarkInterpretSingleFieldStruct(b *testing.B) {
 
 func BenchmarkInterpretNestedStruct(b *testing.B) {
 	assert := assert.New(b)
-	intr := NewInterpreter(nil, functions.GetDefaultFunctions()...)
+	caller := NewFunctionCaller(functions.GetDefaultFunctions()...)
+	intr := NewInterpreter(nil, caller)
 	parser := parsing.NewParser()
 	ast, _ := parser.Parse("fooasdfasdfasdfasdf.fooasdfasdfasdfasdf.fooasdfasdfasdfasdf.fooasdfasdfasdfasdf")
 	data := benchmarkNested{
@@ -234,8 +237,8 @@ func BenchmarkInterpretNestedMaps(b *testing.B) {
 	var data interface{}
 	err := json.Unmarshal(jsonData, &data)
 	assert.Nil(err)
-
-	intr := NewInterpreter(nil, functions.GetDefaultFunctions()...)
+	caller := NewFunctionCaller(functions.GetDefaultFunctions()...)
+	intr := NewInterpreter(nil, caller)
 	parser := parsing.NewParser()
 	ast, _ := parser.Parse("fooasdfasdfasdfasdf.fooasdfasdfasdfasdf.fooasdfasdfasdfasdf.fooasdfasdfasdfasdf")
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
This PR refactors function caller creation to not create one for every search.
Function caller is stateless and can be created once and reused.