### PR TITLE
feat: add execution context support

### DIFF
--- a/cmd/jpgo/main.go
+++ b/cmd/jpgo/main.go
@@ -78,7 +78,7 @@ func run() int {
 	if err := json.Unmarshal(inputData, &data); err != nil {
 		return errMsg("Invalid input JSON: %s", err)
 	}
-	result, err := api.Search(expression, data)
+	result, err := api.Search(expression, data, nil)
 	if err != nil {
 		return errMsg("Error executing expression: %s", err)
 	}

--- a/jp_test.go
+++ b/jp_test.go
@@ -104,7 +104,7 @@ func runSyntaxTestCase(assert *assert.Assertions, given interface{}, testcase Te
 	// Anything with an .Error means that we expect that JMESPath should return
 	// an error when we try to evaluate the expression.
 	// fmt.Println(fmt.Sprintf("%s: %s", filename, testcase.Expression))
-	_, err := Search(testcase.Expression, given)
+	_, err := Search(testcase.Expression, given, nil)
 	assert.NotNil(err, fmt.Sprintf("Expression: %s", testcase.Expression))
 }
 
@@ -124,7 +124,7 @@ func runTestCase(assert *assert.Assertions, given interface{}, testcase TestCase
 		assert.Fail(errMsg)
 		return
 	}
-	actual, err := Search(testcase.Expression, given)
+	actual, err := Search(testcase.Expression, given, nil)
 	if assert.Nil(err, fmt.Sprintf("Expression: %s", testcase.Expression)) {
 		assert.Equal(testcase.Result, actual, fmt.Sprintf("Expression: %s", testcase.Expression))
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -54,7 +54,7 @@ func MustCompile(expression string, funcs ...functions.FunctionEntry) JMESPath {
 // Search evaluates a JMESPath expression against input data and returns the result.
 func (jp jmesPath) Search(data interface{}) (interface{}, error) {
 	intr := interpreter.NewInterpreter(data, jp.caller)
-	return intr.Execute(jp.node, data)
+	return intr.Execute(jp.node, data, nil)
 }
 
 // Search evaluates a JMESPath expression against input data and returns the result.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -11,7 +11,7 @@ import (
 // JMESPath is the representation of a compiled JMES path query. A JMESPath is
 // safe for concurrent use by multiple goroutines.
 type JMESPath interface {
-	Search(interface{}) (interface{}, error)
+	Search(interface{}, interface{}) (interface{}, error)
 }
 
 type jmesPath struct {
@@ -52,16 +52,16 @@ func MustCompile(expression string, funcs ...functions.FunctionEntry) JMESPath {
 }
 
 // Search evaluates a JMESPath expression against input data and returns the result.
-func (jp jmesPath) Search(data interface{}) (interface{}, error) {
+func (jp jmesPath) Search(data interface{}, context interface{}) (interface{}, error) {
 	intr := interpreter.NewInterpreter(data, jp.caller)
-	return intr.Execute(jp.node, data, nil)
+	return intr.Execute(jp.node, data, context)
 }
 
 // Search evaluates a JMESPath expression against input data and returns the result.
-func Search(expression string, data interface{}, funcs ...functions.FunctionEntry) (interface{}, error) {
+func Search(expression string, data interface{}, context interface{}, funcs ...functions.FunctionEntry) (interface{}, error) {
 	compiled, err := Compile(expression, funcs...)
 	if err != nil {
 		return nil, err
 	}
-	return compiled.Search(data)
+	return compiled.Search(data, context)
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -126,7 +126,7 @@ func TestSearch(t *testing.T) {
 		want: nil,
 	}, {
 		args: args{
-			expression: `use_context(&@.a)`,
+			expression: `use_context(&a)`,
 			data: map[string]interface{}{
 				"a": 64.0,
 			},
@@ -135,6 +135,28 @@ func TestSearch(t *testing.T) {
 			},
 		},
 		want: 42.0,
+	}, {
+		args: args{
+			expression: `with_context({ a: 'abc' }, &use_context(&a))`,
+			data: map[string]interface{}{
+				"a": 64.0,
+			},
+			context: map[string]interface{}{
+				"a": 42.0,
+			},
+		},
+		want: "abc",
+	}, {
+		args: args{
+			expression: `with_context({ a: 'abc' }, &[ a, use_context(&a) ])`,
+			data: map[string]interface{}{
+				"a": 64.0,
+			},
+			context: map[string]interface{}{
+				"a": 42.0,
+			},
+		},
+		want: []interface{}{64.0, "abc"},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -44,7 +44,7 @@ func TestInvalidMustCompilePanics(t *testing.T) {
 	MustCompile("not a valid expression")
 }
 
-func jpfEcho(arguments []interface{}) (interface{}, error) {
+func jpfEcho(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return arguments[0], nil
 }
 

--- a/pkg/functions/default.go
+++ b/pkg/functions/default.go
@@ -275,5 +275,20 @@ func GetDefaultFunctions() []FunctionEntry {
 			{Types: []JpType{JpArray}, Variadic: true},
 		},
 		Handler: jpfZip,
+	}, {
+		// experimental context function
+		Name: "with_context",
+		Arguments: []ArgSpec{
+			{Types: []JpType{JpAny}},
+			{Types: []JpType{JpExpref}},
+		},
+		Handler: jpfWithContext,
+	}, {
+		// experimental context function
+		Name: "use_context",
+		Arguments: []ArgSpec{
+			{Types: []JpType{JpExpref}},
+		},
+		Handler: jpfUseContext,
 	}}
 }

--- a/pkg/functions/functions.go
+++ b/pkg/functions/functions.go
@@ -294,7 +294,7 @@ func jpfLower(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return strings.ToLower(arguments[0].(string)), nil
 }
 
-func jpfMap(arguments []interface{}) (interface{}, error) {
+func jpfMap(arguments []interface{}, _ interface{}) (interface{}, error) {
 	exp := arguments[0].(ExpRef)
 	arr := arguments[1].([]interface{})
 	mapped := make([]interface{}, 0, len(arr))

--- a/pkg/functions/functions.go
+++ b/pkg/functions/functions.go
@@ -17,10 +17,15 @@ import (
 )
 
 type (
-	JpFunction = func([]interface{}, interface{}) (interface{}, error)
-	ExpRef     = func(interface{}) (interface{}, error)
+	JpFunction = func([]interface{}) (interface{}, error)
 	JpType     string
 )
+
+type ExpRef interface {
+	Context() interface{}
+	Data() interface{}
+	Execute(interface{}, interface{}) (interface{}, error)
+}
 
 const (
 	JpNumber      JpType = "number"
@@ -104,12 +109,12 @@ func (a *byExprFloat) Less(i, j int) bool {
 	return ith < jth
 }
 
-func jpfAbs(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfAbs(arguments []interface{}) (interface{}, error) {
 	num := arguments[0].(float64)
 	return math.Abs(num), nil
 }
 
-func jpfAvg(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfAvg(arguments []interface{}) (interface{}, error) {
 	// We've already type checked the value so we can safely use
 	// type assertions.
 	args := arguments[0].([]interface{})
@@ -124,12 +129,12 @@ func jpfAvg(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return numerator / length, nil
 }
 
-func jpfCeil(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfCeil(arguments []interface{}) (interface{}, error) {
 	val := arguments[0].(float64)
 	return math.Ceil(val), nil
 }
 
-func jpfContains(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfContains(arguments []interface{}) (interface{}, error) {
 	search := arguments[0]
 	el := arguments[1]
 	if searchStr, ok := search.(string); ok {
@@ -148,7 +153,7 @@ func jpfContains(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return false, nil
 }
 
-func jpfEndsWith(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfEndsWith(arguments []interface{}) (interface{}, error) {
 	search := arguments[0].(string)
 	suffix := arguments[1].(string)
 	return strings.HasSuffix(search, suffix), nil
@@ -190,20 +195,20 @@ func jpfFindImpl(name string, arguments []interface{}, find func(s string, subst
 	return float64(start + offset), nil
 }
 
-func jpfFindFirst(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfFindFirst(arguments []interface{}) (interface{}, error) {
 	return jpfFindImpl("find_first", arguments, strings.Index)
 }
 
-func jpfFindLast(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfFindLast(arguments []interface{}) (interface{}, error) {
 	return jpfFindImpl("find_last", arguments, strings.LastIndex)
 }
 
-func jpfFloor(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfFloor(arguments []interface{}) (interface{}, error) {
 	val := arguments[0].(float64)
 	return math.Floor(val), nil
 }
 
-func jpfFromItems(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfFromItems(arguments []interface{}) (interface{}, error) {
 	if arr, ok := util.ToArrayArray(arguments[0]); ok {
 		result := make(map[string]interface{})
 		for _, item := range arr {
@@ -222,7 +227,7 @@ func jpfFromItems(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return nil, errors.New("invalid type, first argument must be an array of arrays")
 }
 
-func jpfGroupBy(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfGroupBy(arguments []interface{}) (interface{}, error) {
 	arr := arguments[0].([]interface{})
 	exp := arguments[1].(ExpRef)
 	if len(arr) == 0 {
@@ -230,7 +235,7 @@ func jpfGroupBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 	}
 	groups := map[string]interface{}{}
 	for _, element := range arr {
-		spec, err := exp(element)
+		spec, err := exp.Execute(element, exp.Context())
 		if err != nil {
 			return nil, err
 		}
@@ -246,7 +251,7 @@ func jpfGroupBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return groups, nil
 }
 
-func jpfItems(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfItems(arguments []interface{}) (interface{}, error) {
 	value := arguments[0].(map[string]interface{})
 	arrays := []interface{}{}
 	for key, item := range value {
@@ -257,7 +262,7 @@ func jpfItems(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return arrays, nil
 }
 
-func jpfJoin(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfJoin(arguments []interface{}) (interface{}, error) {
 	sep := arguments[0].(string)
 	// We can't just do arguments[1].([]string), we have to
 	// manually convert each item to a string.
@@ -268,7 +273,7 @@ func jpfJoin(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return strings.Join(arrayStr, sep), nil
 }
 
-func jpfKeys(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfKeys(arguments []interface{}) (interface{}, error) {
 	arg := arguments[0].(map[string]interface{})
 	collected := make([]interface{}, 0, len(arg))
 	for key := range arg {
@@ -277,7 +282,7 @@ func jpfKeys(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return collected, nil
 }
 
-func jpfLength(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfLength(arguments []interface{}) (interface{}, error) {
 	arg := arguments[0]
 	if c, ok := arg.(string); ok {
 		return float64(utf8.RuneCountInString(c)), nil
@@ -290,16 +295,16 @@ func jpfLength(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return nil, errors.New("could not compute length()")
 }
 
-func jpfLower(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfLower(arguments []interface{}) (interface{}, error) {
 	return strings.ToLower(arguments[0].(string)), nil
 }
 
-func jpfMap(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfMap(arguments []interface{}) (interface{}, error) {
 	exp := arguments[0].(ExpRef)
 	arr := arguments[1].([]interface{})
 	mapped := make([]interface{}, 0, len(arr))
 	for _, value := range arr {
-		current, err := exp(value)
+		current, err := exp.Execute(value, exp.Context())
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +313,7 @@ func jpfMap(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return mapped, nil
 }
 
-func jpfMax(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfMax(arguments []interface{}) (interface{}, error) {
 	if items, ok := util.ToArrayNum(arguments[0]); ok {
 		if len(items) == 0 {
 			return nil, nil
@@ -341,7 +346,7 @@ func jpfMax(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return best, nil
 }
 
-func jpfMaxBy(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfMaxBy(arguments []interface{}) (interface{}, error) {
 	arr := arguments[0].([]interface{})
 	exp := arguments[1].(ExpRef)
 	if len(arr) == 0 {
@@ -349,7 +354,7 @@ func jpfMaxBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 	} else if len(arr) == 1 {
 		return arr[0], nil
 	}
-	start, err := exp(arr[0])
+	start, err := exp.Execute(arr[0], exp.Context())
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +363,7 @@ func jpfMaxBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 		bestVal := t
 		bestItem := arr[0]
 		for _, item := range arr[1:] {
-			result, err := exp(item)
+			result, err := exp.Execute(item, exp.Context())
 			if err != nil {
 				return nil, err
 			}
@@ -376,7 +381,7 @@ func jpfMaxBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 		bestVal := t
 		bestItem := arr[0]
 		for _, item := range arr[1:] {
-			result, err := exp(item)
+			result, err := exp.Execute(item, exp.Context())
 			if err != nil {
 				return nil, err
 			}
@@ -395,7 +400,7 @@ func jpfMaxBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 	}
 }
 
-func jpfMerge(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfMerge(arguments []interface{}) (interface{}, error) {
 	final := make(map[string]interface{})
 	for _, m := range arguments {
 		mapped := m.(map[string]interface{})
@@ -406,7 +411,7 @@ func jpfMerge(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return final, nil
 }
 
-func jpfMin(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfMin(arguments []interface{}) (interface{}, error) {
 	if items, ok := util.ToArrayNum(arguments[0]); ok {
 		if len(items) == 0 {
 			return nil, nil
@@ -438,7 +443,7 @@ func jpfMin(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return best, nil
 }
 
-func jpfMinBy(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfMinBy(arguments []interface{}) (interface{}, error) {
 	arr := arguments[0].([]interface{})
 	exp := arguments[1].(ExpRef)
 	if len(arr) == 0 {
@@ -446,7 +451,7 @@ func jpfMinBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 	} else if len(arr) == 1 {
 		return arr[0], nil
 	}
-	start, err := exp(arr[0])
+	start, err := exp.Execute(arr[0], exp.Context())
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +459,7 @@ func jpfMinBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 		bestVal := t
 		bestItem := arr[0]
 		for _, item := range arr[1:] {
-			result, err := exp(item)
+			result, err := exp.Execute(item, exp.Context())
 			if err != nil {
 				return nil, err
 			}
@@ -472,7 +477,7 @@ func jpfMinBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 		bestVal := t
 		bestItem := arr[0]
 		for _, item := range arr[1:] {
-			result, err := exp(item)
+			result, err := exp.Execute(item, exp.Context())
 			if err != nil {
 				return nil, err
 			}
@@ -491,7 +496,7 @@ func jpfMinBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 	}
 }
 
-func jpfNotNull(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfNotNull(arguments []interface{}) (interface{}, error) {
 	for _, arg := range arguments {
 		if arg != nil {
 			return arg, nil
@@ -517,11 +522,11 @@ func jpfPadImpl(name string, arguments []interface{}, pad func(s string, width i
 	return pad(s, width, chars), nil
 }
 
-func jpfPadLeft(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfPadLeft(arguments []interface{}) (interface{}, error) {
 	return jpfPadImpl("pad_left", arguments, padLeft)
 }
 
-func jpfPadRight(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfPadRight(arguments []interface{}) (interface{}, error) {
 	return jpfPadImpl("pad_right", arguments, padRight)
 }
 
@@ -539,7 +544,7 @@ func padRight(s string, width int, pad string) string {
 	return result
 }
 
-func jpfReplace(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfReplace(arguments []interface{}) (interface{}, error) {
 	subject := arguments[0].(string)
 	old := arguments[1].(string)
 	new := arguments[2].(string)
@@ -555,7 +560,7 @@ func jpfReplace(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return strings.Replace(subject, old, new, count), nil
 }
 
-func jpfReverse(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfReverse(arguments []interface{}) (interface{}, error) {
 	if s, ok := arguments[0].(string); ok {
 		r := []rune(s)
 		for i, j := 0, len(r)-1; i < len(r)/2; i, j = i+1, j-1 {
@@ -572,7 +577,7 @@ func jpfReverse(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return reversed, nil
 }
 
-func jpfSort(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfSort(arguments []interface{}) (interface{}, error) {
 	if items, ok := util.ToArrayNum(arguments[0]); ok {
 		d := sort.Float64Slice(items)
 		sort.Stable(d)
@@ -593,7 +598,7 @@ func jpfSort(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return final, nil
 }
 
-func jpfSortBy(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfSortBy(arguments []interface{}) (interface{}, error) {
 	arr := arguments[0].([]interface{})
 	exp := arguments[1].(ExpRef)
 	if len(arr) == 0 {
@@ -603,7 +608,7 @@ func jpfSortBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 	}
 	var sortKeys []interface{}
 	for _, item := range arr {
-		if value, err := exp(item); err != nil {
+		if value, err := exp.Execute(item, exp.Context()); err != nil {
 			return nil, err
 		} else {
 			sortKeys = append(sortKeys, value)
@@ -628,7 +633,7 @@ func jpfSortBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 	}
 }
 
-func jpfSplit(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfSplit(arguments []interface{}) (interface{}, error) {
 	s := arguments[0].(string)
 	if len(s) == 0 {
 		return []interface{}{}, nil
@@ -665,13 +670,13 @@ func jpfSplit(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return result, nil
 }
 
-func jpfStartsWith(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfStartsWith(arguments []interface{}) (interface{}, error) {
 	search := arguments[0].(string)
 	prefix := arguments[1].(string)
 	return strings.HasPrefix(search, prefix), nil
 }
 
-func jpfSum(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfSum(arguments []interface{}) (interface{}, error) {
 	items, _ := util.ToArrayNum(arguments[0])
 	sum := 0.0
 	for _, item := range items {
@@ -680,14 +685,14 @@ func jpfSum(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return sum, nil
 }
 
-func jpfToArray(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfToArray(arguments []interface{}) (interface{}, error) {
 	if _, ok := arguments[0].([]interface{}); ok {
 		return arguments[0], nil
 	}
 	return arguments[:1:1], nil
 }
 
-func jpfToString(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfToString(arguments []interface{}) (interface{}, error) {
 	if v, ok := arguments[0].(string); ok {
 		return v, nil
 	}
@@ -698,7 +703,7 @@ func jpfToString(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return string(result), nil
 }
 
-func jpfToNumber(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfToNumber(arguments []interface{}) (interface{}, error) {
 	arg := arguments[0]
 	if v, ok := arg.(float64); ok {
 		return v, nil
@@ -738,19 +743,19 @@ func jpfTrimImpl(arguments []interface{}, trimSpace func(s string, predicate fun
 	return trim(s, cutset), nil
 }
 
-func jpfTrim(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfTrim(arguments []interface{}) (interface{}, error) {
 	return jpfTrimImpl(arguments, strings.TrimFunc, strings.Trim)
 }
 
-func jpfTrimLeft(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfTrimLeft(arguments []interface{}) (interface{}, error) {
 	return jpfTrimImpl(arguments, strings.TrimLeftFunc, strings.TrimLeft)
 }
 
-func jpfTrimRight(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfTrimRight(arguments []interface{}) (interface{}, error) {
 	return jpfTrimImpl(arguments, strings.TrimRightFunc, strings.TrimRight)
 }
 
-func jpfType(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfType(arguments []interface{}) (interface{}, error) {
 	arg := arguments[0]
 	if _, ok := arg.(float64); ok {
 		return "number", nil
@@ -773,11 +778,11 @@ func jpfType(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return nil, errors.New("unknown type")
 }
 
-func jpfUpper(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfUpper(arguments []interface{}) (interface{}, error) {
 	return strings.ToUpper(arguments[0].(string)), nil
 }
 
-func jpfValues(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfValues(arguments []interface{}) (interface{}, error) {
 	arg := arguments[0].(map[string]interface{})
 	collected := make([]interface{}, 0, len(arg))
 	for _, value := range arg {
@@ -786,7 +791,7 @@ func jpfValues(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return collected, nil
 }
 
-func jpfZip(arguments []interface{}, _ interface{}) (interface{}, error) {
+func jpfZip(arguments []interface{}) (interface{}, error) {
 	// determine how many items are present
 	// for each array in the result
 
@@ -809,4 +814,16 @@ func jpfZip(arguments []interface{}, _ interface{}) (interface{}, error) {
 	}
 
 	return result, nil
+}
+
+// experimental context functions
+
+func jpfWithContext(arguments []interface{}) (interface{}, error) {
+	exp := arguments[1].(ExpRef)
+	return exp.Execute(exp.Data(), arguments[0])
+}
+
+func jpfUseContext(arguments []interface{}) (interface{}, error) {
+	exp := arguments[0].(ExpRef)
+	return exp.Execute(exp.Context(), nil)
 }

--- a/pkg/functions/functions.go
+++ b/pkg/functions/functions.go
@@ -18,7 +18,7 @@ import (
 
 type (
 	JpFunction = func([]interface{}) (interface{}, error)
-	ExpRef     = func(interface{}) (interface{}, error)
+	ExpRef     = func(interface{} /*, map[string]interface{}*/) (interface{}, error)
 	JpType     string
 )
 

--- a/pkg/functions/functions.go
+++ b/pkg/functions/functions.go
@@ -17,8 +17,8 @@ import (
 )
 
 type (
-	JpFunction = func([]interface{}) (interface{}, error)
-	ExpRef     = func(interface{} /*, map[string]interface{}*/) (interface{}, error)
+	JpFunction = func([]interface{}, interface{}) (interface{}, error)
+	ExpRef     = func(interface{}) (interface{}, error)
 	JpType     string
 )
 
@@ -104,12 +104,12 @@ func (a *byExprFloat) Less(i, j int) bool {
 	return ith < jth
 }
 
-func jpfAbs(arguments []interface{}) (interface{}, error) {
+func jpfAbs(arguments []interface{}, _ interface{}) (interface{}, error) {
 	num := arguments[0].(float64)
 	return math.Abs(num), nil
 }
 
-func jpfAvg(arguments []interface{}) (interface{}, error) {
+func jpfAvg(arguments []interface{}, _ interface{}) (interface{}, error) {
 	// We've already type checked the value so we can safely use
 	// type assertions.
 	args := arguments[0].([]interface{})
@@ -124,12 +124,12 @@ func jpfAvg(arguments []interface{}) (interface{}, error) {
 	return numerator / length, nil
 }
 
-func jpfCeil(arguments []interface{}) (interface{}, error) {
+func jpfCeil(arguments []interface{}, _ interface{}) (interface{}, error) {
 	val := arguments[0].(float64)
 	return math.Ceil(val), nil
 }
 
-func jpfContains(arguments []interface{}) (interface{}, error) {
+func jpfContains(arguments []interface{}, _ interface{}) (interface{}, error) {
 	search := arguments[0]
 	el := arguments[1]
 	if searchStr, ok := search.(string); ok {
@@ -148,7 +148,7 @@ func jpfContains(arguments []interface{}) (interface{}, error) {
 	return false, nil
 }
 
-func jpfEndsWith(arguments []interface{}) (interface{}, error) {
+func jpfEndsWith(arguments []interface{}, _ interface{}) (interface{}, error) {
 	search := arguments[0].(string)
 	suffix := arguments[1].(string)
 	return strings.HasSuffix(search, suffix), nil
@@ -190,20 +190,20 @@ func jpfFindImpl(name string, arguments []interface{}, find func(s string, subst
 	return float64(start + offset), nil
 }
 
-func jpfFindFirst(arguments []interface{}) (interface{}, error) {
+func jpfFindFirst(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return jpfFindImpl("find_first", arguments, strings.Index)
 }
 
-func jpfFindLast(arguments []interface{}) (interface{}, error) {
+func jpfFindLast(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return jpfFindImpl("find_last", arguments, strings.LastIndex)
 }
 
-func jpfFloor(arguments []interface{}) (interface{}, error) {
+func jpfFloor(arguments []interface{}, _ interface{}) (interface{}, error) {
 	val := arguments[0].(float64)
 	return math.Floor(val), nil
 }
 
-func jpfFromItems(arguments []interface{}) (interface{}, error) {
+func jpfFromItems(arguments []interface{}, _ interface{}) (interface{}, error) {
 	if arr, ok := util.ToArrayArray(arguments[0]); ok {
 		result := make(map[string]interface{})
 		for _, item := range arr {
@@ -222,7 +222,7 @@ func jpfFromItems(arguments []interface{}) (interface{}, error) {
 	return nil, errors.New("invalid type, first argument must be an array of arrays")
 }
 
-func jpfGroupBy(arguments []interface{}) (interface{}, error) {
+func jpfGroupBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 	arr := arguments[0].([]interface{})
 	exp := arguments[1].(ExpRef)
 	if len(arr) == 0 {
@@ -246,7 +246,7 @@ func jpfGroupBy(arguments []interface{}) (interface{}, error) {
 	return groups, nil
 }
 
-func jpfItems(arguments []interface{}) (interface{}, error) {
+func jpfItems(arguments []interface{}, _ interface{}) (interface{}, error) {
 	value := arguments[0].(map[string]interface{})
 	arrays := []interface{}{}
 	for key, item := range value {
@@ -257,7 +257,7 @@ func jpfItems(arguments []interface{}) (interface{}, error) {
 	return arrays, nil
 }
 
-func jpfJoin(arguments []interface{}) (interface{}, error) {
+func jpfJoin(arguments []interface{}, _ interface{}) (interface{}, error) {
 	sep := arguments[0].(string)
 	// We can't just do arguments[1].([]string), we have to
 	// manually convert each item to a string.
@@ -268,7 +268,7 @@ func jpfJoin(arguments []interface{}) (interface{}, error) {
 	return strings.Join(arrayStr, sep), nil
 }
 
-func jpfKeys(arguments []interface{}) (interface{}, error) {
+func jpfKeys(arguments []interface{}, _ interface{}) (interface{}, error) {
 	arg := arguments[0].(map[string]interface{})
 	collected := make([]interface{}, 0, len(arg))
 	for key := range arg {
@@ -277,7 +277,7 @@ func jpfKeys(arguments []interface{}) (interface{}, error) {
 	return collected, nil
 }
 
-func jpfLength(arguments []interface{}) (interface{}, error) {
+func jpfLength(arguments []interface{}, _ interface{}) (interface{}, error) {
 	arg := arguments[0]
 	if c, ok := arg.(string); ok {
 		return float64(utf8.RuneCountInString(c)), nil
@@ -290,7 +290,7 @@ func jpfLength(arguments []interface{}) (interface{}, error) {
 	return nil, errors.New("could not compute length()")
 }
 
-func jpfLower(arguments []interface{}) (interface{}, error) {
+func jpfLower(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return strings.ToLower(arguments[0].(string)), nil
 }
 
@@ -308,7 +308,7 @@ func jpfMap(arguments []interface{}) (interface{}, error) {
 	return mapped, nil
 }
 
-func jpfMax(arguments []interface{}) (interface{}, error) {
+func jpfMax(arguments []interface{}, _ interface{}) (interface{}, error) {
 	if items, ok := util.ToArrayNum(arguments[0]); ok {
 		if len(items) == 0 {
 			return nil, nil
@@ -341,7 +341,7 @@ func jpfMax(arguments []interface{}) (interface{}, error) {
 	return best, nil
 }
 
-func jpfMaxBy(arguments []interface{}) (interface{}, error) {
+func jpfMaxBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 	arr := arguments[0].([]interface{})
 	exp := arguments[1].(ExpRef)
 	if len(arr) == 0 {
@@ -395,7 +395,7 @@ func jpfMaxBy(arguments []interface{}) (interface{}, error) {
 	}
 }
 
-func jpfMerge(arguments []interface{}) (interface{}, error) {
+func jpfMerge(arguments []interface{}, _ interface{}) (interface{}, error) {
 	final := make(map[string]interface{})
 	for _, m := range arguments {
 		mapped := m.(map[string]interface{})
@@ -406,7 +406,7 @@ func jpfMerge(arguments []interface{}) (interface{}, error) {
 	return final, nil
 }
 
-func jpfMin(arguments []interface{}) (interface{}, error) {
+func jpfMin(arguments []interface{}, _ interface{}) (interface{}, error) {
 	if items, ok := util.ToArrayNum(arguments[0]); ok {
 		if len(items) == 0 {
 			return nil, nil
@@ -438,7 +438,7 @@ func jpfMin(arguments []interface{}) (interface{}, error) {
 	return best, nil
 }
 
-func jpfMinBy(arguments []interface{}) (interface{}, error) {
+func jpfMinBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 	arr := arguments[0].([]interface{})
 	exp := arguments[1].(ExpRef)
 	if len(arr) == 0 {
@@ -491,7 +491,7 @@ func jpfMinBy(arguments []interface{}) (interface{}, error) {
 	}
 }
 
-func jpfNotNull(arguments []interface{}) (interface{}, error) {
+func jpfNotNull(arguments []interface{}, _ interface{}) (interface{}, error) {
 	for _, arg := range arguments {
 		if arg != nil {
 			return arg, nil
@@ -500,11 +500,7 @@ func jpfNotNull(arguments []interface{}) (interface{}, error) {
 	return nil, nil
 }
 
-func jpfPadImpl(
-	name string,
-	arguments []interface{},
-	pad func(s string, width int, pad string) string,
-) (interface{}, error) {
+func jpfPadImpl(name string, arguments []interface{}, pad func(s string, width int, pad string) string) (interface{}, error) {
 	s := arguments[0].(string)
 	width, ok := util.ToPositiveInteger(arguments[1])
 	if !ok {
@@ -521,11 +517,11 @@ func jpfPadImpl(
 	return pad(s, width, chars), nil
 }
 
-func jpfPadLeft(arguments []interface{}) (interface{}, error) {
+func jpfPadLeft(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return jpfPadImpl("pad_left", arguments, padLeft)
 }
 
-func jpfPadRight(arguments []interface{}) (interface{}, error) {
+func jpfPadRight(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return jpfPadImpl("pad_right", arguments, padRight)
 }
 
@@ -543,7 +539,7 @@ func padRight(s string, width int, pad string) string {
 	return result
 }
 
-func jpfReplace(arguments []interface{}) (interface{}, error) {
+func jpfReplace(arguments []interface{}, _ interface{}) (interface{}, error) {
 	subject := arguments[0].(string)
 	old := arguments[1].(string)
 	new := arguments[2].(string)
@@ -559,7 +555,7 @@ func jpfReplace(arguments []interface{}) (interface{}, error) {
 	return strings.Replace(subject, old, new, count), nil
 }
 
-func jpfReverse(arguments []interface{}) (interface{}, error) {
+func jpfReverse(arguments []interface{}, _ interface{}) (interface{}, error) {
 	if s, ok := arguments[0].(string); ok {
 		r := []rune(s)
 		for i, j := 0, len(r)-1; i < len(r)/2; i, j = i+1, j-1 {
@@ -576,7 +572,7 @@ func jpfReverse(arguments []interface{}) (interface{}, error) {
 	return reversed, nil
 }
 
-func jpfSort(arguments []interface{}) (interface{}, error) {
+func jpfSort(arguments []interface{}, _ interface{}) (interface{}, error) {
 	if items, ok := util.ToArrayNum(arguments[0]); ok {
 		d := sort.Float64Slice(items)
 		sort.Stable(d)
@@ -597,7 +593,7 @@ func jpfSort(arguments []interface{}) (interface{}, error) {
 	return final, nil
 }
 
-func jpfSortBy(arguments []interface{}) (interface{}, error) {
+func jpfSortBy(arguments []interface{}, _ interface{}) (interface{}, error) {
 	arr := arguments[0].([]interface{})
 	exp := arguments[1].(ExpRef)
 	if len(arr) == 0 {
@@ -632,7 +628,7 @@ func jpfSortBy(arguments []interface{}) (interface{}, error) {
 	}
 }
 
-func jpfSplit(arguments []interface{}) (interface{}, error) {
+func jpfSplit(arguments []interface{}, _ interface{}) (interface{}, error) {
 	s := arguments[0].(string)
 	if len(s) == 0 {
 		return []interface{}{}, nil
@@ -669,13 +665,13 @@ func jpfSplit(arguments []interface{}) (interface{}, error) {
 	return result, nil
 }
 
-func jpfStartsWith(arguments []interface{}) (interface{}, error) {
+func jpfStartsWith(arguments []interface{}, _ interface{}) (interface{}, error) {
 	search := arguments[0].(string)
 	prefix := arguments[1].(string)
 	return strings.HasPrefix(search, prefix), nil
 }
 
-func jpfSum(arguments []interface{}) (interface{}, error) {
+func jpfSum(arguments []interface{}, _ interface{}) (interface{}, error) {
 	items, _ := util.ToArrayNum(arguments[0])
 	sum := 0.0
 	for _, item := range items {
@@ -684,14 +680,14 @@ func jpfSum(arguments []interface{}) (interface{}, error) {
 	return sum, nil
 }
 
-func jpfToArray(arguments []interface{}) (interface{}, error) {
+func jpfToArray(arguments []interface{}, _ interface{}) (interface{}, error) {
 	if _, ok := arguments[0].([]interface{}); ok {
 		return arguments[0], nil
 	}
 	return arguments[:1:1], nil
 }
 
-func jpfToString(arguments []interface{}) (interface{}, error) {
+func jpfToString(arguments []interface{}, _ interface{}) (interface{}, error) {
 	if v, ok := arguments[0].(string); ok {
 		return v, nil
 	}
@@ -702,7 +698,7 @@ func jpfToString(arguments []interface{}) (interface{}, error) {
 	return string(result), nil
 }
 
-func jpfToNumber(arguments []interface{}) (interface{}, error) {
+func jpfToNumber(arguments []interface{}, _ interface{}) (interface{}, error) {
 	arg := arguments[0]
 	if v, ok := arg.(float64); ok {
 		return v, nil
@@ -729,11 +725,7 @@ func jpfToNumber(arguments []interface{}) (interface{}, error) {
 	return nil, errors.New("unknown type")
 }
 
-func jpfTrimImpl(
-	arguments []interface{},
-	trimSpace func(s string, predicate func(r rune) bool) string,
-	trim func(s string, cutset string) string,
-) (interface{}, error) {
+func jpfTrimImpl(arguments []interface{}, trimSpace func(s string, predicate func(r rune) bool) string, trim func(s string, cutset string) string) (interface{}, error) {
 	s := arguments[0].(string)
 	cutset := ""
 	if len(arguments) > 1 {
@@ -746,19 +738,19 @@ func jpfTrimImpl(
 	return trim(s, cutset), nil
 }
 
-func jpfTrim(arguments []interface{}) (interface{}, error) {
+func jpfTrim(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return jpfTrimImpl(arguments, strings.TrimFunc, strings.Trim)
 }
 
-func jpfTrimLeft(arguments []interface{}) (interface{}, error) {
+func jpfTrimLeft(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return jpfTrimImpl(arguments, strings.TrimLeftFunc, strings.TrimLeft)
 }
 
-func jpfTrimRight(arguments []interface{}) (interface{}, error) {
+func jpfTrimRight(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return jpfTrimImpl(arguments, strings.TrimRightFunc, strings.TrimRight)
 }
 
-func jpfType(arguments []interface{}) (interface{}, error) {
+func jpfType(arguments []interface{}, _ interface{}) (interface{}, error) {
 	arg := arguments[0]
 	if _, ok := arg.(float64); ok {
 		return "number", nil
@@ -781,11 +773,11 @@ func jpfType(arguments []interface{}) (interface{}, error) {
 	return nil, errors.New("unknown type")
 }
 
-func jpfUpper(arguments []interface{}) (interface{}, error) {
+func jpfUpper(arguments []interface{}, _ interface{}) (interface{}, error) {
 	return strings.ToUpper(arguments[0].(string)), nil
 }
 
-func jpfValues(arguments []interface{}) (interface{}, error) {
+func jpfValues(arguments []interface{}, _ interface{}) (interface{}, error) {
 	arg := arguments[0].(map[string]interface{})
 	collected := make([]interface{}, 0, len(arg))
 	for _, value := range arg {
@@ -794,7 +786,7 @@ func jpfValues(arguments []interface{}) (interface{}, error) {
 	return collected, nil
 }
 
-func jpfZip(arguments []interface{}) (interface{}, error) {
+func jpfZip(arguments []interface{}, _ interface{}) (interface{}, error) {
 	// determine how many items are present
 	// for each array in the result
 

--- a/pkg/interpreter/functions.go
+++ b/pkg/interpreter/functions.go
@@ -10,7 +10,7 @@ import (
 )
 
 type FunctionCaller interface {
-	CallFunction(string, []interface{}, interface{}) (interface{}, error)
+	CallFunction(string, []interface{}) (interface{}, error)
 }
 
 type functionEntry struct {
@@ -146,7 +146,7 @@ func typeCheck(a functions.ArgSpec, arg interface{}) error {
 	return fmt.Errorf("invalid type for: %v, expected: %#v", arg, a.Types)
 }
 
-func (f *functionCaller) CallFunction(name string, arguments []interface{}, context interface{}) (interface{}, error) {
+func (f *functionCaller) CallFunction(name string, arguments []interface{}) (interface{}, error) {
 	entry, ok := f.functionTable[name]
 	if !ok {
 		return nil, errors.New("unknown function: " + name)
@@ -155,5 +155,5 @@ func (f *functionCaller) CallFunction(name string, arguments []interface{}, cont
 	if err != nil {
 		return nil, err
 	}
-	return entry.handler(resolvedArgs, context)
+	return entry.handler(resolvedArgs)
 }

--- a/pkg/interpreter/functions.go
+++ b/pkg/interpreter/functions.go
@@ -10,7 +10,7 @@ import (
 )
 
 type FunctionCaller interface {
-	CallFunction(string, []interface{}) (interface{}, error)
+	CallFunction(string, []interface{}, interface{}) (interface{}, error)
 }
 
 type functionEntry struct {
@@ -146,7 +146,7 @@ func typeCheck(a functions.ArgSpec, arg interface{}) error {
 	return fmt.Errorf("invalid type for: %v, expected: %#v", arg, a.Types)
 }
 
-func (f *functionCaller) CallFunction(name string, arguments []interface{}) (interface{}, error) {
+func (f *functionCaller) CallFunction(name string, arguments []interface{}, context interface{}) (interface{}, error) {
 	entry, ok := f.functionTable[name]
 	if !ok {
 		return nil, errors.New("unknown function: " + name)
@@ -155,5 +155,5 @@ func (f *functionCaller) CallFunction(name string, arguments []interface{}) (int
 	if err != nil {
 		return nil, err
 	}
-	return entry.handler(resolvedArgs)
+	return entry.handler(resolvedArgs, context)
 }

--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -131,7 +131,7 @@ func (intr *treeInterpreter) Execute(node parsing.ASTNode, value interface{}, co
 			}
 			resolvedArgs = append(resolvedArgs, current)
 		}
-		return intr.caller.CallFunction(node.Value.(string), resolvedArgs)
+		return intr.caller.CallFunction(node.Value.(string), resolvedArgs, context)
 	case parsing.ASTField:
 		key := node.Value.(string)
 		var result interface{}

--- a/pkg/interpreter/interpreter_test.go
+++ b/pkg/interpreter/interpreter_test.go
@@ -53,7 +53,7 @@ func search(t *testing.T, expression string, data interface{}) (interface{}, err
 	}
 	caller := NewFunctionCaller(functions.GetDefaultFunctions()...)
 	intr := NewInterpreter(nil, caller)
-	return intr.Execute(ast, data)
+	return intr.Execute(ast, data, nil)
 }
 
 func TestCanSupportEmptyInterface(t *testing.T) {
@@ -203,7 +203,7 @@ func BenchmarkInterpretSingleFieldStruct(b *testing.B) {
 	ast, _ := parser.Parse("fooasdfasdfasdfasdf")
 	data := benchmarkStruct{"foobarbazqux"}
 	for i := 0; i < b.N; i++ {
-		_, err := intr.Execute(ast, data)
+		_, err := intr.Execute(ast, data, nil)
 		if err != nil {
 			assert.Fail("Received error from interpreter")
 		}
@@ -224,7 +224,7 @@ func BenchmarkInterpretNestedStruct(b *testing.B) {
 		},
 	}
 	for i := 0; i < b.N; i++ {
-		_, err := intr.Execute(ast, data)
+		_, err := intr.Execute(ast, data, nil)
 		if err != nil {
 			assert.Fail("Received error from interpreter")
 		}
@@ -242,7 +242,7 @@ func BenchmarkInterpretNestedMaps(b *testing.B) {
 	parser := parsing.NewParser()
 	ast, _ := parser.Parse("fooasdfasdfasdfasdf.fooasdfasdfasdfasdf.fooasdfasdfasdfasdf.fooasdfasdfasdfasdf")
 	for i := 0; i < b.N; i++ {
-		_, err := intr.Execute(ast, data)
+		_, err := intr.Execute(ast, data, nil)
 		if err != nil {
 			assert.Fail("Received error from interpreter")
 		}


### PR DESCRIPTION
This PR adds experimental execution context support.

It adds two functions:
- `with_context`: first argument is the context for the scope of the function, second argument is an expression reference
- `use_context`: takes one expression reference to be evaluated against the context

```
Data: { "a": 64.0 }
Context: { "a": 42.0 }

Program: use_context(&a) -> 42.0
Program: with_context({ a: 'abc' }, &use_context(&a)) -> 'abc'
Program: with_context({ a: 'abc' }, &[ a, use_context(&a) ]) -> [ 64.0, 'abc' ]
```

cc @springcomp 