### PR TITLE
fix: pipe evaluation to multi-select-hash

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -123,6 +123,13 @@ func TestSearch(t *testing.T) {
 			},
 		},
 		want: nil,
+	}, {
+		args: args{
+			expression: "`null` | {foo: @}",
+		},
+		want: map[string]interface{}{
+			"foo": nil,
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -240,9 +240,6 @@ func (intr *treeInterpreter) Execute(node parsing.ASTNode, value interface{}) (i
 	case parsing.ASTLiteral:
 		return node.Value, nil
 	case parsing.ASTMultiSelectHash:
-		if value == nil {
-			return nil, nil
-		}
 		collected := make(map[string]interface{})
 		for _, child := range node.Children {
 			current, err := intr.Execute(child, value)


### PR DESCRIPTION
This PR fixes pipe evaluation to multi-select-hash.

Fixes #54 

CC @springcomp how can run compliance tests for this ?
Do i need to reference a file here https://github.com/jmespath-community/go-jmespath/blob/46c049439f431ac4a7920434aaa3ff9a46d7e2ab/jp_test.go#L27-L50 ?