### PR TITLE
clone compliance tests when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ generate:
 
 build:
 	rm -f $(CMD)
+	git submodule update --init --checkout --recursive --force
 	go build ./...
 	rm -f cmd/$(CMD)/$(CMD) && cd cmd/$(CMD)/ && go build ./...
 	mv cmd/$(CMD)/$(CMD) .


### PR DESCRIPTION
This PR runs the `` git submodule update `` command during `` make build `` to bring compliance tests into scope for testing.