### PR TITLE
refactor: introduce Binding interface to make system extensible

### DIFF
--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -1,37 +1,22 @@
 package binding
 
-import "fmt"
-
-// Bindings stores let expression bindings by name.
-type Bindings interface {
+// Binding in the interface representing a let expression binding.
+// You can get the value of the binding by calling the `Value` method.
+type Binding interface {
 	// Get returns the value bound for a given name.
-	Get(string) (interface{}, error)
-	// Register registers a value associated with a given name, it returns a new binding
-	Register(string, interface{}) Bindings
+	Value() (interface{}, error)
 }
 
-type bindings struct {
-	values map[string]interface{}
+type binding struct {
+	value interface{}
 }
 
-func NewBindings() Bindings {
-	return bindings{}
+func (b *binding) Value() (interface{}, error) {
+	return b.value, nil
 }
 
-func (b bindings) Get(name string) (interface{}, error) {
-	if value, ok := b.values[name]; ok {
-		return value, nil
-	}
-	return nil, fmt.Errorf("variable not defined: %s", name)
-}
-
-func (b bindings) Register(name string, value interface{}) Bindings {
-	values := map[string]interface{}{}
-	for k, v := range b.values {
-		values[k] = v
-	}
-	values[name] = value
-	return bindings{
-		values: values,
+func NewBinding(value interface{}) Binding {
+	return &binding{
+		value: value,
 	}
 }

--- a/pkg/binding/binding_test.go
+++ b/pkg/binding/binding_test.go
@@ -5,138 +5,76 @@ import (
 	"testing"
 )
 
-func TestNewBindings(t *testing.T) {
+func TestNewBinding(t *testing.T) {
 	tests := []struct {
-		name string
-		want Bindings
+		name  string
+		value interface{}
+		want  Binding
 	}{{
-		want: bindings{},
+		name:  "nil",
+		value: nil,
+		want:  &binding{nil},
+	}, {
+		name:  "int",
+		value: int(42),
+		want:  &binding{int(42)},
+	}, {
+		name:  "string",
+		value: "42",
+		want:  &binding{"42"},
+	}, {
+		name:  "array",
+		value: []interface{}{"42", 42},
+		want:  &binding{[]interface{}{"42", 42}},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewBindings(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewBindings() = %v, want %v", got, tt.want)
+			if got := NewBinding(tt.value); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewBinding() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func Test_bindings_Get(t *testing.T) {
-	type fields struct {
-		values map[string]interface{}
-	}
-	type args struct {
-		name string
-	}
+func Test_binding_Value(t *testing.T) {
 	tests := []struct {
 		name    string
-		fields  fields
-		args    args
+		value   interface{}
 		want    interface{}
 		wantErr bool
 	}{{
-		fields: fields{
-			values: nil,
-		},
-		args: args{
-			name: "$root",
-		},
-		wantErr: true,
+		name:    "nil",
+		value:   nil,
+		want:    nil,
+		wantErr: false,
 	}, {
-		fields: fields{
-			values: map[string]interface{}{},
-		},
-		args: args{
-			name: "$root",
-		},
-		wantErr: true,
+		name:    "int",
+		value:   int(42),
+		want:    int(42),
+		wantErr: false,
 	}, {
-		fields: fields{
-			values: map[string]interface{}{
-				"$root": 42.0,
-			},
-		},
-		args: args{
-			name: "$root",
-		},
-		want: 42.0,
+		name:    "string",
+		value:   "42",
+		want:    "42",
+		wantErr: false,
 	}, {
-		fields: fields{
-			values: map[string]interface{}{
-				"$foot": 42.0,
-			},
-		},
-		args: args{
-			name: "$root",
-		},
-		wantErr: true,
+		name:    "array",
+		value:   []interface{}{"42", 42},
+		want:    []interface{}{"42", 42},
+		wantErr: false,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := bindings{
-				values: tt.fields.values,
+			b := &binding{
+				value: tt.value,
 			}
-			got, err := b.Get(tt.args.name)
+			got, err := b.Value()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("bindings.Get() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("binding.Value() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("bindings.Get() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_bindings_Register(t *testing.T) {
-	type fields struct {
-		values map[string]interface{}
-	}
-	type args struct {
-		name  string
-		value interface{}
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   Bindings
-	}{{
-		fields: fields{
-			values: nil,
-		},
-		args: args{
-			name:  "$root",
-			value: 42.0,
-		},
-		want: bindings{
-			values: map[string]interface{}{
-				"$root": 42.0,
-			},
-		},
-	}, {
-		fields: fields{
-			values: map[string]interface{}{
-				"$root": 21.0,
-			},
-		},
-		args: args{
-			name:  "$root",
-			value: 42.0,
-		},
-		want: bindings{
-			values: map[string]interface{}{
-				"$root": 42.0,
-			},
-		},
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			b := bindings{
-				values: tt.fields.values,
-			}
-			if got := b.Register(tt.args.name, tt.args.value); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("bindings.Register() = %v, want %v", got, tt.want)
+				t.Errorf("binding.Value() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/binding/bindings.go
+++ b/pkg/binding/bindings.go
@@ -1,0 +1,39 @@
+package binding
+
+import (
+	"fmt"
+)
+
+// Bindings stores let expression bindings by name.
+type Bindings interface {
+	// Get returns the binding for a given name.
+	Get(string) (Binding, error)
+	// Register registers a binding associated with a given name, it returns a new binding
+	Register(string, Binding) Bindings
+}
+
+type bindings struct {
+	bindings map[string]Binding
+}
+
+func NewBindings() Bindings {
+	return bindings{}
+}
+
+func (b bindings) Get(name string) (Binding, error) {
+	if value, ok := b.bindings[name]; ok {
+		return value, nil
+	}
+	return nil, fmt.Errorf("variable not defined: %s", name)
+}
+
+func (b bindings) Register(name string, binding Binding) Bindings {
+	values := map[string]Binding{}
+	for k, v := range b.bindings {
+		values[k] = v
+	}
+	values[name] = binding
+	return bindings{
+		bindings: values,
+	}
+}

--- a/pkg/binding/bindings_test.go
+++ b/pkg/binding/bindings_test.go
@@ -1,0 +1,143 @@
+package binding
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewBindings(t *testing.T) {
+	tests := []struct {
+		name string
+		want Bindings
+	}{{
+		want: bindings{},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewBindings(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewBindings() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_bindings_Get(t *testing.T) {
+	type fields struct {
+		values map[string]Binding
+	}
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    Binding
+		wantErr bool
+	}{{
+		fields: fields{
+			values: nil,
+		},
+		args: args{
+			name: "$root",
+		},
+		wantErr: true,
+	}, {
+		fields: fields{
+			values: map[string]Binding{},
+		},
+		args: args{
+			name: "$root",
+		},
+		wantErr: true,
+	}, {
+		fields: fields{
+			values: map[string]Binding{
+				"$root": &binding{42.0},
+			},
+		},
+		args: args{
+			name: "$root",
+		},
+		want: &binding{42.0},
+	}, {
+		fields: fields{
+			values: map[string]Binding{
+				"$foot": &binding{42.0},
+			},
+		},
+		args: args{
+			name: "$root",
+		},
+		wantErr: true,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := bindings{
+				bindings: tt.fields.values,
+			}
+			got, err := b.Get(tt.args.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("bindings.Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("bindings.Get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_bindings_Register(t *testing.T) {
+	type fields struct {
+		values map[string]Binding
+	}
+	type args struct {
+		name  string
+		value Binding
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   Bindings
+	}{{
+		fields: fields{
+			values: nil,
+		},
+		args: args{
+			name:  "$root",
+			value: &binding{42.0},
+		},
+		want: bindings{
+			bindings: map[string]Binding{
+				"$root": &binding{42.0},
+			},
+		},
+	}, {
+		fields: fields{
+			values: map[string]Binding{
+				"$root": &binding{21.0},
+			},
+		},
+		args: args{
+			name:  "$root",
+			value: &binding{42.0},
+		},
+		want: bindings{
+			bindings: map[string]Binding{
+				"$root": &binding{42.0},
+			},
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := bindings{
+				bindings: tt.fields.values,
+			}
+			if got := b.Register(tt.args.name, tt.args.value); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("bindings.Register() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/binding/resolve.go
+++ b/pkg/binding/resolve.go
@@ -1,0 +1,16 @@
+package binding
+
+import (
+	"errors"
+)
+
+func Resolve(name string, bindings Bindings) (interface{}, error) {
+	if bindings == nil {
+		return nil, errors.New("bindings must not be nil")
+	}
+	binding, err := bindings.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	return binding.Value()
+}

--- a/pkg/binding/resolve_test.go
+++ b/pkg/binding/resolve_test.go
@@ -1,0 +1,55 @@
+package binding
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolve(t *testing.T) {
+	type args struct {
+		name     string
+		bindings Bindings
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{{
+		name: "nil",
+		args: args{
+			name:     "$test",
+			bindings: nil,
+		},
+		want:    nil,
+		wantErr: true,
+	}, {
+		name: "enmpty",
+		args: args{
+			name:     "",
+			bindings: NewBindings().Register("$test", NewBinding(42)),
+		},
+		want:    nil,
+		wantErr: true,
+	}, {
+		name: "ok",
+		args: args{
+			name:     "$test",
+			bindings: NewBindings().Register("$test", NewBinding(42)),
+		},
+		want:    42,
+		wantErr: false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Resolve(tt.args.name, tt.args.bindings)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Resolve() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Resolve() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -223,7 +223,7 @@ func (intr *treeInterpreter) Execute(node parsing.ASTNode, value interface{}) (i
 			if value, err := intr.Execute(child.Children[1], value); err != nil {
 				return nil, err
 			} else {
-				bindings = bindings.Register(child.Children[0].Value.(string), value)
+				bindings = bindings.Register(child.Children[0].Value.(string), binding.NewBinding(value))
 			}
 		}
 		intr.bindings = bindings
@@ -245,7 +245,7 @@ func (intr *treeInterpreter) Execute(node parsing.ASTNode, value interface{}) (i
 			return value, nil
 		}
 	case parsing.ASTVariable:
-		if value, err := intr.bindings.Get(node.Value.(string)); err != nil {
+		if value, err := binding.Resolve(node.Value.(string), intr.bindings); err != nil {
 			return nil, err
 		} else {
 			return value, nil


### PR DESCRIPTION
This PR introduces the `Binding` interface to make system extensible.

Can be used for things like lazy binding, binding to an external data source, etc...