### PR TITLE
chore: add go 1.21 and 1.22 in ci jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,8 @@ jobs:
           - '1.18'
           - '1.19'
           - '1.20'
+          - '1.21'
+          - '1.22'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Add go 1.21 and 1.22 in ci jobs.