### PR TITLE
Make options public to allow custom interpreter usage

### DIFF
--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -43,13 +43,13 @@ func NewInterpreter(data interface{}, bindings binding.Bindings) Interpreter {
 // It will produce the result of applying the JMESPath expression associated
 // with the ASTNode to the input data "value".
 func (intr *treeInterpreter) Execute(node parsing.ASTNode, value interface{}, opts ...Option) (interface{}, error) {
-	var o options
+	var o Options
 	for _, opt := range opts {
 		if opt != nil {
 			o = opt(o)
 		}
 	}
-	functionCaller := o.functionCaller
+	functionCaller := o.FunctionCaller
 	if functionCaller == nil {
 		functionCaller = DefaultFunctionCaller
 	}

--- a/pkg/interpreter/option.go
+++ b/pkg/interpreter/option.go
@@ -1,14 +1,14 @@
 package interpreter
 
-type Option func(options) options
+type Option func(Options) Options
 
-type options struct {
-	functionCaller FunctionCaller
+type Options struct {
+	FunctionCaller FunctionCaller
 }
 
 func WithFunctionCaller(functionCaller FunctionCaller) Option {
-	return func(o options) options {
-		o.functionCaller = functionCaller
+	return func(o Options) Options {
+		o.FunctionCaller = functionCaller
 		return o
 	}
 }


### PR DESCRIPTION
To allow the creation and usage of a custom Interpreter it is necessary that the `Options` struct is public to fulfill the interface and make the usage of the `Option` interface possible.