### PR TITLE
feat: add delegate binding support

### DIFF
--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -15,8 +15,18 @@ func (b *binding) Value() (any, error) {
 	return b.value, nil
 }
 
-func NewBinding(value any) Binding {
+func NewBinding(value any) *binding {
 	return &binding{
 		value: value,
 	}
+}
+
+type delegate func() (any, error)
+
+func (b delegate) Value() (any, error) {
+	return b()
+}
+
+func NewDelegate(delegate func() (any, error)) delegate {
+	return delegate
 }


### PR DESCRIPTION
Add delegate binding support.

Combine this with `sync.OnceValues` and you have a powerful lazy binding system :)

```go
binding.NewDelegate(sync.OnceValues(func() (any, error) {
    return ...
}))
```