### PR TITLE
Please, consider replacing golint with staticcheck

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,5 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,18 +32,31 @@ jobs:
         run: go mod download
       - name: Tests
         run: make test
-      - name: Install golint
-        if: ${{ matrix.go-version == '1.17' }}
-        run: |
-          make install-dev-cmds
-          make check
+
+  static-check:
+    name: Run Static Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.18'
+      - name: Install deps 
+        run: go mod download
+      - name: go vet ./...
+        run: go vet ./...
+      # TODO: improve with caching
+      - uses: dominikh/staticcheck-action@v1.2.0
+        with:
+          version: "2022.1.1"
+          install-go: false
+          min-go-version: "1.18"
 
   golangci-lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,11 +6,11 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    - copyloopvar
     # - cyclop
     # - deadcode
     - decorder
     # - depguard
-    - dogsled
     - dupl
     - dupword
     - durationcheck
@@ -18,11 +18,9 @@ linters:
     - errchkjson
     - errname
     # - errorlint
-    - execinquery
     # - exhaustive
     # - exhaustivestruct
     # - exhaustruct
-    - exportloopref
     # - forbidigo
     # - forcetypeassert
     # - funlen
@@ -38,8 +36,6 @@ linters:
     # - goerr113
     - gofmt
     - gofumpt
-
-
     - prealloc
     # - predeclared
     - promlinter
@@ -48,7 +44,7 @@ linters:
     - rowserrcheck
     # - scopelint
     - sqlclosecheck
-    - staticcheck
+    # - staticcheck
     # - structcheck
     - stylecheck
     - tagliatelle

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test: build
 
 check:
 	go vet ./...
-	golint ./...
+	staticcheck ./...
 	golangci-lint run
 
 htmlc:
@@ -42,6 +42,6 @@ pprof-cpu:
 	go tool pprof ./go-jmespath.test ./cpu.out
 
 install-dev-cmds:
-	go install golang.org/x/lint/golint@latest
+	go install honnef.co/go/tools/cmd/staticcheck@latest
 	go install golang.org/x/tools/cmd/stringer@latest
 	command -v golangci-lint || { curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.46.2; }

--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -16,9 +16,9 @@ import (
 var DefaultFunctionCaller FunctionCaller = NewFunctionCaller(functions.GetDefaultFunctions()...)
 
 /*
-This is a tree based interpreter.  It walks the AST and directly
-
-	interprets the AST to search through a JSON document.
+Interpreter is a tree based interpreter.
+It walks and interprets the AST directly
+to search through a JSON document.
 */
 type Interpreter interface {
 	Execute(parsing.ASTNode, any, ...Option) (any, error)

--- a/pkg/parsing/lexer.go
+++ b/pkg/parsing/lexer.go
@@ -154,7 +154,7 @@ func (lexer *Lexer) peek() rune {
 	return t
 }
 
-// tokenize takes an expression and returns corresponding tokens.
+// Tokenize takes an expression and returns corresponding tokens.
 func (lexer *Lexer) Tokenize(expression string) ([]token, error) {
 	var tokens []token
 	lexer.expression = expression

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -17,6 +17,9 @@ func TestSlicePositiveStep(t *testing.T) {
 	result, err := Slice(input, []SliceParam{{0, true}, {3, true}, {1, true}})
 	assert.Nil(err)
 	assert.Equal(input[:3], result)
+	if err == err {
+		assert.Nil(err)
+	}
 }
 
 func TestIsFalseJSONTypes(t *testing.T) {

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,34 @@
+checks = [
+	"all",
+	"-SA9003",
+	"-ST1000",
+	"-ST1003",
+	"-ST1016",
+	"-ST1020",
+	"-ST1021",
+	"-ST1022",
+	"-ST1023",
+]
+initialisms = [
+	"ACL", "AMQP", "API", "ASCII",
+	"CPU", "CSS",
+	"DB", "DNS",
+	"EOF",
+	"GID", "GUID",
+	"HTML", "HTTP", "HTTPS",
+	"ID", "IP",
+	"JSON",
+	"QPS",
+	"RAM", "RPC", "RTP",
+	"SIP", "SLA", "SMTP", "SQL", "SSH",
+	"TCP", "TLS", "TS", "TTL",
+	"UDP", "UI", "UID", "UUID", "URI", "URL", "UTF8",
+	"VM",
+	"XML", "XMPP", "XSRF", "XSS",
+]
+dot_import_whitelist = [
+	"github.com/mmcloughlin/avo/build",
+	"github.com/mmcloughlin/avo/operand",
+	"github.com/mmcloughlin/avo/reg"
+]
+http_status_code_whitelist = ["200", "400", "404", "500"]


### PR DESCRIPTION
It seems `golint` has become obsolete and the repository [is archived by its owner](https://github.com/golang/lint).
The author suggests alternatives such as `go vet` and `staticcheck`.

This PR replaces `golint` with `staticcheck` using the default configuration.
