### PR TITLE
Added missing codecov token

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -37,8 +37,10 @@ jobs:
       with:
         name: coverage.out
     - name: Upload Report to Codecov
-      uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         files: ./coverage.out
         fail_ci_if_error: true
         verbose: true
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+- cmd/
+- jp.go


### PR DESCRIPTION
And excluding the following files to maintain good coverage:

- `jp.go`
- `cmd/jpgo/main.go`